### PR TITLE
Eclipse plugin fix

### DIFF
--- a/install/Eclipse-JPF.md
+++ b/install/Eclipse-JPF.md
@@ -1,3 +1,3 @@
 # eclipse-jpf #
 
-Due to recent changes in JPF,Eclipse plugin support was withdrawn.
+Due to recent changes in JPF, Eclipse plugin support was withdrawn.

--- a/install/Eclipse-JPF.md
+++ b/install/Eclipse-JPF.md
@@ -1,24 +1,3 @@
 # eclipse-jpf #
 
-This is a plugin to launch JPF on selected application property files (*.jpf) from within Eclipse. This plugin is the Eclipse analog to netbeans-jpf. This plugin is minimal by design and serves mostly to start an external JPF process from within Eclipse.
-
-To this end, the plugin adds a "Verify.." popup menu item for *.jpf files that are selected in the package explorer window. 
-
-Depending on the selected application property file, output will appear either in the eclipse console view or a jpf-shell.
-
-The site.properties location can be entered in the "JPF Preferences" pane within the normal Eclipse Preferences window. The default location is `$HOME/.jpf/site.properties`.
- 
-
-This project is *not* a normal JPF project, i.e. it does not follow the usual JPF directory structure and artifacts. This is an Eclipse plugin project that builds into a jar file (attached) that installs into Eclipse as a plugin. Of course that means you need an Eclipse installation that includes the Plugin Development Environment (PDE) in order to build this project.
-
-### Repository ###
-The eclipse-jpf source repository is located on http://babelfish.arc.nasa.gov/hg/jpf/eclipse-jpf
-
-### Installation ###
-If you have the eclipse PDE installed, the preferred way is to get the eclipse-jpf sources from the repository, build via the eclipse plugin Export Wizard into the <eclipse-home>/dropins folder and restart eclipse.
-
-If you don't have the eclipse PDE, you can either install this plugin via "Eclipse/Help/Install New Software..." by entering the the eclipse-jpf update site URL: 
-
-      http://babelfish.arc.nasa.gov/trac/jpf/raw-attachment/wiki/projects/eclipse-jpf/update
-
-or download the attached eclipse-jpf_<version>.jar file and move it into your <eclipse-home>/dropins folder. In both cases, you need to restart eclipse in order to load the plugin. Note however that this might not be the latest eclipse-jpf version and it might or might not work with your eclipse.
+Due to recent changes in JPF,Eclipse plugin support was withdrawn.

--- a/install/Eclipse-Plugin.md
+++ b/install/Eclipse-Plugin.md
@@ -1,3 +1,3 @@
 # Installing the Eclipse JPF plugin #
 
-Due to recent changes in JPF,Eclipse plugin support was withdrawn.
+Due to recent changes in JPF, Eclipse plugin support was withdrawn.

--- a/install/Eclipse-Plugin.md
+++ b/install/Eclipse-Plugin.md
@@ -1,15 +1,3 @@
 # Installing the Eclipse JPF plugin #
 
-Note that this is assuming the latest Eclipse and Java versions, which is Eclipse 4.3.x and Java 7 at the time of this writing. Older versions might or might not work.
-There are three different ways to install the plugin, which are listed in the order of preference if you want to ensure that you are using the latest plugin version:
-
-### Build from sources ###
-If you have the Eclipse Plugin Development Environment installed (PDE -comes with standard Eclipse distribution), the preferred way is to download the [eclipse-jpf](./eclipse-jpf) sources from the repository, build the plugin into your <eclipse>/dropins/plugins directory, and restart Eclipse. This ensures you are using the latest version of the plugin, and the build process will tell you if your Eclipse is compatible.
-
-### Install from attached plugin jar ###
-Alternatively, you can download one of the attached eclipse-jpf_<version>.jar files, place it into your <eclipse>/dropins/plugins directory, and restart Eclipse.
-
-### Install from update site ###
-The most convenient, but least up-to-date way to install eclipse-jpf is to use the Eclipse/Help/Install New Software... dialog, by entering the the eclipse-jpf update site URL:
-
-     http://babelfish.arc.nasa.gov/trac/jpf/raw-attachment/wiki/projects/eclipse-jpf/update
+Due to recent changes in JPF,Eclipse plugin support was withdrawn.

--- a/install/eclipse-plugin/Eclipse-JPF-update.md
+++ b/install/eclipse-plugin/Eclipse-JPF-update.md
@@ -1,1 +1,1 @@
-Due to recent changes in JPF,Eclipse plugin support was withdrawn.
+Due to recent changes in JPF, Eclipse plugin support was withdrawn.

--- a/install/eclipse-plugin/Eclipse-JPF-update.md
+++ b/install/eclipse-plugin/Eclipse-JPF-update.md
@@ -1,1 +1,1 @@
-This is the target location for the eclipse-jpf update site.
+Due to recent changes in JPF,Eclipse plugin support was withdrawn.


### PR DESCRIPTION
The JPF Eclipse plugin support was withdrawn  but the wiki was still giving instructions and providing link to download Eclipse plugin version of JPF so I fixed it by providing correct information.